### PR TITLE
Do not notify user of question edits

### DIFF
--- a/anspress_email.php
+++ b/anspress_email.php
@@ -564,6 +564,9 @@ class AnsPress_Ext_AnsPress_Email
 
 	public function ap_after_update_question($question_id) {
 
+		if ( ! ap_opt( 'notify_admin_edit_question' ) ) {
+			return; }
+			
 		$current_user = wp_get_current_user();
 
 		$question = get_post( $question_id );


### PR DESCRIPTION
Consistent with "edit answers" and "trash entities", this is not really something users need to know.
Not interfering with notification code, just adding same check that is present on other "questionable" notifications.
